### PR TITLE
Adding a toml to help get rid of the setup.py deprecation notice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,14 @@
-[tool.poetry]
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+
+[project]
 name = "gpt3-prompt-to-text"
 description = "gpt3-prompt-to-text is a command line program that converts a prompt into text using OpenAI's GPT-3 API."
 license = "MIT"
-
-[build-system]
-requires = ["setuptools>=40.8.0", "wheel"]
+readme = "README.md"
+authors = ["Clemens Vasters <clemens@vasters.com>"]
+repository = "https://github.com/clemensv/gpt3-prompt-to-text"
+homepage = "https://github.com/clemensv/gpt3-prompt-to-text"
 
 [tool.setuptools]
 name = "gpt3-prompt-to-text"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ version = "1.1.1"
 repository = "https://github.com/clemensv/gpt3-prompt-to-text"
 homepage = "https://github.com/clemensv/gpt3-prompt-to-text"
 
-[tool.setuptools]
-name = "gpt3-prompt-to-text"
-
 [tool.setuptools.find_packages]
 include = ["gpt3_prompt_to_text"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[tool.poetry]
+name = "gpt3-prompt-to-text"
+description = "gpt3-prompt-to-text is a command line program that converts a prompt into text using OpenAI's GPT-3 API."
+license = "MIT"
+
 [build-system]
 requires = ["setuptools>=40.8.0", "wheel"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,6 @@ homepage = "https://github.com/clemensv/gpt3-prompt-to-text"
 packages = ["gpt3_prompt_to_text"]
 
 [console_scripts]
-gpt3-prompt-to-text = gpt3_prompt_to_text.gpt3_prompt_to_text:main
+gpt3-prompt-to-text = "gpt3_prompt_to_text.gpt3_prompt_to_text:main"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = ["setuptools>=40.8.0", "wheel"]
 [project]
 name = "gpt3-prompt-to-text"
 description = "gpt3-prompt-to-text is a command line program that converts a prompt into text using OpenAI's GPT-3 API."
-license = "MIT"
 readme = "README.md"
 authors = ["Clemens Vasters <clemens@vasters.com>"]
 repository = "https://github.com/clemensv/gpt3-prompt-to-text"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 name = "gpt3-prompt-to-text"
 description = "gpt3-prompt-to-text is a command line program that converts a prompt into text using OpenAI's GPT-3 API."
 readme = "README.md"
-authors = ["Clemens Vasters <clemens@vasters.com>"]
+authors = [{name = "Clemens Vasters", email = "clemens@vasters.com"}]
 repository = "https://github.com/clemensv/gpt3-prompt-to-text"
 homepage = "https://github.com/clemensv/gpt3-prompt-to-text"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ name = "gpt3-prompt-to-text"
 description = "gpt3-prompt-to-text is a command line program that converts a prompt into text using OpenAI's GPT-3 API."
 readme = "README.md"
 authors = [{name = "Clemens Vasters", email = "clemens@vasters.com"}]
+
+[project.urls]
 repository = "https://github.com/clemensv/gpt3-prompt-to-text"
 homepage = "https://github.com/clemensv/gpt3-prompt-to-text"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+
+[tool.setuptools]
+name = "gpt3-prompt-to-text"
+use_scm_version = True
+
+[tool.setuptools.find_packages]
+include = ["gpt3_prompt_to_text"]
+
+[tool.setuptools.entry_points]
+console_scripts = [
+    "gpt3-prompt-to-text = gpt3_prompt_to_text.gpt3_prompt_to_text:main"
+]
+
+[tool.setuptools.install_requires]
+openai = "*"
+setuptools_scm = "*"
+
+[tool.setuptools.setup_requires]
+setuptools_scm = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,23 +6,20 @@ name = "gpt3-prompt-to-text"
 description = "gpt3-prompt-to-text is a command line program that converts a prompt into text using OpenAI's GPT-3 API."
 readme = "README.md"
 authors = [{name = "Clemens Vasters", email = "clemens@vasters.com"}]
-version = "1.1.1"
+dependencies = [
+  "openai",
+  "setuptools_scm"
+]
+dynamic = ["version"]
 
 [project.urls]
 repository = "https://github.com/clemensv/gpt3-prompt-to-text"
 homepage = "https://github.com/clemensv/gpt3-prompt-to-text"
 
-[tool.setuptools.find_packages]
-include = ["gpt3_prompt_to_text"]
+[tool.setuptools]
+packages = ["gpt3_prompt_to_text"]
 
-[tool.setuptools.entry_points]
-console_scripts = [
-    "gpt3-prompt-to-text = gpt3_prompt_to_text.gpt3_prompt_to_text:main"
-]
+[console_scripts]
+gpt3-prompt-to-text = gpt3_prompt_to_text.gpt3_prompt_to_text:main
 
-[tool.setuptools.install_requires]
-openai = "*"
-setuptools_scm = "*"
-
-[tool.setuptools.setup_requires]
-setuptools_scm = "*"
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 
 [tool.setuptools]
 name = "gpt3-prompt-to-text"
-use_scm_version = True
+use_scm_version = true
 
 [tool.setuptools.find_packages]
 include = ["gpt3_prompt_to_text"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ name = "gpt3-prompt-to-text"
 description = "gpt3-prompt-to-text is a command line program that converts a prompt into text using OpenAI's GPT-3 API."
 readme = "README.md"
 authors = [{name = "Clemens Vasters", email = "clemens@vasters.com"}]
+version = "1.1.1"
 
 [project.urls]
 repository = "https://github.com/clemensv/gpt3-prompt-to-text"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ homepage = "https://github.com/clemensv/gpt3-prompt-to-text"
 
 [tool.setuptools]
 name = "gpt3-prompt-to-text"
-use_scm_version = true
 
 [tool.setuptools.find_packages]
 include = ["gpt3_prompt_to_text"]


### PR DESCRIPTION
Eliminates this:

DEPRECATION: gpt3-prompt-to-text is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559